### PR TITLE
Making plugin configuration more verbose and added customization section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ HTML file inputs suck... it is difficult to upload more than one file at a time.
 ## Customization example
 You can customize plugin by setting target container (using jquery selectors) for uploaded files and specifying template for each file
 
-    $('#file_input').multifile({
+    $('.multifile').multifile({
         container: "#upload-container",
         template: function (file) {
             var fileName = file.name;

--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ HTML file inputs suck... it is difficult to upload more than one file at a time.
 ### JavaScript
     $('.multifile').multifile();
 
+## Customization example
+You can customize plugin by setting target container (using jquery selectors) for uploaded files and specifying template for each file
+
+    $('#file_input').multifile({
+        container: "#upload-container",
+        template: function (file) {
+            var fileName = file.name;
+            var fileExtension = file.name.split('.').pop();
+
+            var result =
+                '<p class="uploaded_image">' +
+                '<a href="#" class="multifile_remove_input">Close me</a>' +
+                '<span class="filename">$fileName ($fileExtension)</span>' +
+                '</p>';
+
+            result = result.replace('$fileExtension', fileExtension).replace('$fileName', fileName)
+
+            return $(result);
+        }
+    })
+
 ## Plugins
 
 ### jquery.multifile.preview

--- a/jquery.multifile.js
+++ b/jquery.multifile.js
@@ -6,8 +6,11 @@
  * uploading more than one file at a time.
  */
 ;(function($, global, undefined){
-  $.fn.multifile = function(container, templateCb)
+  $.fn.multifile = function(attributes)
   {
+    var container = attributes['container'];
+    var templateCb = attributes['template'];
+
     var $container
       , addInput = function(event)
         {

--- a/jquery.multifile.js
+++ b/jquery.multifile.js
@@ -6,10 +6,16 @@
  * uploading more than one file at a time.
  */
 ;(function($, global, undefined){
-  $.fn.multifile = function(attributes)
+  $.fn.multifile = function(containerOrAttributes, templateCb)
   {
-    var container = attributes['container'];
-    var templateCb = attributes['template'];
+    var container;
+
+    if (typeof containerOrAttributes == "object") {
+      container = containerOrAttributes['container'];
+      templateCb = containerOrAttributes['template'];
+    } else {
+      container = containerOrAttributes;
+    }
 
     var $container
       , addInput = function(event)


### PR DESCRIPTION
Plugin gives some basic customization options but it's not mentioned neither in readme nor on example website. I had to go through source code in order to find if I can set custom template - I believe this feature is important enough to make it more visible for developers.
